### PR TITLE
feat: suppress spurious output

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -19,7 +19,7 @@ fi
 # when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
 redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
 version=
-printf "redirect url: %s\n" "$redirect_url" >&2
+# DEBUG: printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
 	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
 else


### PR DESCRIPTION
This is really a debug message for the plugin developer. Users should not see this. It originally came from the plugin template.

To my knowledge, there are no existing flags/env vars to instruct debug output, so we just commented it out for now.